### PR TITLE
Complete execFile migration in BeadsService helpers

### DIFF
--- a/apps/server/src/services/beads-service.ts
+++ b/apps/server/src/services/beads-service.ts
@@ -266,8 +266,8 @@ export class BeadsService {
     type: 'blocks' | 'related' | 'parent' | 'discovered-from'
   ): Promise<void> {
     try {
-      const command = `bd dep add ${issueId} ${depId} --type ${type}`;
-      await execAsync(command, { cwd: projectPath });
+      const args = ['dep', 'add', issueId, depId, '--type', type];
+      await execFileAsync('bd', args, { cwd: projectPath });
     } catch (error) {
       throw new Error(`Failed to add dependency: ${error}`);
     }
@@ -278,8 +278,8 @@ export class BeadsService {
    */
   async removeDependency(projectPath: string, issueId: string, depId: string): Promise<void> {
     try {
-      const command = `bd dep remove ${issueId} ${depId}`;
-      await execAsync(command, { cwd: projectPath });
+      const args = ['dep', 'remove', issueId, depId];
+      await execFileAsync('bd', args, { cwd: projectPath });
     } catch (error) {
       throw new Error(`Failed to remove dependency: ${error}`);
     }
@@ -290,11 +290,11 @@ export class BeadsService {
    */
   async getReadyWork(projectPath: string, limit?: number): Promise<any[]> {
     try {
-      let command = 'bd ready --json';
+      const args = ['ready', '--json'];
       if (limit) {
-        command += ` --limit ${limit}`;
+        args.push('--limit', String(limit));
       }
-      const { stdout } = await execAsync(command, { cwd: projectPath });
+      const { stdout } = await execFileAsync('bd', args, { cwd: projectPath });
       const issues = JSON.parse(stdout);
       return issues;
     } catch (error) {
@@ -310,7 +310,7 @@ export class BeadsService {
    */
   async getStats(projectPath: string): Promise<any> {
     try {
-      const { stdout } = await execAsync('bd stats --json', { cwd: projectPath });
+      const { stdout } = await execFileAsync('bd', ['stats', '--json'], { cwd: projectPath });
       const stats = JSON.parse(stdout);
       return stats;
     } catch (error) {
@@ -331,7 +331,7 @@ export class BeadsService {
    */
   async sync(projectPath: string): Promise<void> {
     try {
-      await execAsync('bd sync', { cwd: projectPath });
+      await execFileAsync('bd', ['sync'], { cwd: projectPath });
     } catch (error) {
       throw new Error(`Failed to sync database: ${error}`);
     }


### PR DESCRIPTION
### Motivation

- Prevent command injection and fragile shell interpolation by switching all Beads CLI invocations to argument-based `execFile` usage.
- Align UI and server payload formats for Beads create/update operations so requests match the server expectations.
- Make Beads operations more robust and consistent by removing ad-hoc shell command construction.

### Description

- Replaced ad-hoc shell commands with `execFile` (promisified as `execFileAsync`) across the `BeadsService`, including `addDependency`, `removeDependency`, `getReadyWork`, `getStats`, and `sync`.
- Updated existing `list`, `get`, `create`, `update`, and `delete` implementations to build argument arrays and call `execFileAsync('bd', args, { cwd })` instead of interpolating strings.
- Updated the UI API client in `apps/ui/src/lib/http-api-client.ts` to send create payloads as `{ issue: ... }` and update payloads as `{ updates: ... }` to match the server endpoints.
- Kept existing error handling and return shapes intact to preserve endpoint compatibility.

### Testing

- Ran `npm run typecheck --workspace=apps/ui` which failed because the `@automaker/ui` workspace is missing a `typecheck` script.
- Ran `npm run lint --workspace=apps/ui` which failed with linting errors (110 problems: 8 errors, 102 warnings).
- Attempted to run `bd ready` but the `bd` CLI is not available in the environment, so end-to-end Beads CLI behavior could not be exercised here.
- Confirmed no remaining references to the removed `execAsync` helper in `apps/server/src/services/beads-service.ts` and committed the refactor changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694be65722188326a101a1007a14ad64)